### PR TITLE
Patch to make PLplot work with Numpy-2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ tmp/
 # Ignore Mac OS X generated file/directory attribute storage files
 \.DS_Store
 \._\.DS_Store
+
+# Ignore CLion config/buils directory
+.idea/
+cmake-build-debug/

--- a/bindings/python/Pltk_init.i
+++ b/bindings/python/Pltk_init.i
@@ -24,7 +24,7 @@
 %{
 #define NPY_NO_DEPRECATED_API    NPY_1_7_API_VERSION
 #include <Python.h>
-#include <arrayobject.h>
+#include <numpy/arrayobject.h>
 #include "plplot.h"
 #include "plplotP.h"
 

--- a/bindings/python/plplotc.i
+++ b/bindings/python/plplotc.i
@@ -50,7 +50,7 @@
 
 %{
 #define NPY_NO_DEPRECATED_API    NPY_1_7_API_VERSION
-#include <arrayobject.h>
+#include <numpy/arrayobject.h>
 #include "plplot.h"
 #include "plplotP.h"
 

--- a/cmake/modules/python.cmake
+++ b/cmake/modules/python.cmake
@@ -107,20 +107,18 @@ if(ENABLE_python)
     execute_process(
       COMMAND
       ${PYTHON_EXECUTABLE} -c "import numpy; print(numpy.get_include())"
-      OUTPUT_VARIABLE NUMPY_INCLUDE_PATH_PARENT
+      OUTPUT_VARIABLE NUMPY_GET_INCLUDE
       RESULT_VARIABLE NUMPY_ERR
       OUTPUT_STRIP_TRAILING_WHITESPACE
       )
     if(NUMPY_ERR)
       set(NUMPY_INCLUDE_PATH)
     else(NUMPY_ERR)
-      # We use the full path name (including numpy on the end), but
-      # Double-check that all is well with that choice.
       find_path(
-	NUMPY_INCLUDE_PATH
-	arrayobject.h
-	${NUMPY_INCLUDE_PATH_PARENT}/numpy
-	)
+	    NUMPY_INCLUDE_PATH
+        numpy/arrayobject.h
+	    ${NUMPY_GET_INCLUDE}
+	  )
     endif(NUMPY_ERR)
 
   endif(NOT NUMPY_INCLUDE_PATH)


### PR DESCRIPTION
Currently, PLplot does not build with Numpy-2.0.0. I made a bug report ober there (https://github.com/numpy/numpy/issues/26854) and we figured, it is PLplot, which is not using the intended include directory but the "numpy" subdirectory.

This patch corrects the used include dir as wenn as the include statements that are generated by swig.

Best, Jan